### PR TITLE
fix: TOTAL_INCREASING for cumulative energy sensors

### DIFF
--- a/custom_components/deye_cloud/helpers.py
+++ b/custom_components/deye_cloud/helpers.py
@@ -55,7 +55,7 @@ def get_sensor_attributes(unit: str, key: str) -> dict:
     if safe_unit == "kw":
         return {"device_class": SensorDeviceClass.POWER, "native_unit_of_measurement": unit, "state_class": SensorStateClass.MEASUREMENT}
     if safe_unit == "kwh":
-        if "total" in key or "daily" in key:
+        if "total" in key or "daily" in key or "cumulative" in key:
             return {"device_class": SensorDeviceClass.ENERGY, "native_unit_of_measurement": unit, "state_class": SensorStateClass.TOTAL_INCREASING}
         return {"device_class": SensorDeviceClass.ENERGY, "native_unit_of_measurement": unit, "state_class": SensorStateClass.MEASUREMENT}
     if safe_unit == "hz":


### PR DESCRIPTION
### Testing

Tested on a real Deye install (single-phase hybrid inverter) running the
integration via HACS:
- After the fix and a full HA restart, the three `Cumulative*` sensors
  report `state_class: total_increasing`.
- The `last_reset` warning in the Energy dashboard is gone and the
  sensors can be selected for grid import/export.
- Values accumulate correctly across import/export cycles with no
  spurious resets.